### PR TITLE
Update influxdb dependency to point to new repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: go
 
 go:
-  - 1.8.x
+  - 1.11.x

--- a/Readme.md
+++ b/Readme.md
@@ -4,7 +4,7 @@
 [![Build Status](https://travis-ci.org/timatooth/gofit.svg?branch=master)](https://travis-ci.org/timatooth/gofit)
 
 ### Requirements
-* Go 1.8+
+* Go 1.11+
 * Fitbit API App ID/Secret (You need to request your own personal App keys in the Fitbit dashboard)
 * InfluxDB 1.2
 * Grafana 4.2+

--- a/gofit.go
+++ b/gofit.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"time"
 
-	client "github.com/influxdata/influxdb/client/v2"
+	client "github.com/influxdata/influxdb1-client/v2"
 	"github.com/timatooth/gofit/fitbitapi"
 )
 


### PR DESCRIPTION
Upstream influxdata/infludb [moved the v2 Go client](https://github.com/influxdata/influxdb/commit/32c63cd038a6d44b8b30790845223265223d2cb2) to this new repo.